### PR TITLE
 Open the USB device only after discovering it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,7 @@ LDFLAGS += -undefined dynamic_lookup
 endif
 endif
 
-# BUILD_DIR := $(PWD)/_build
-
-PRIV_DIR := priv
+PRIV_DIR := $(MIX_APP_PATH)/priv
 LIBUSB_NIF := $(PRIV_DIR)/libusb_nif.so
 
 .PHONY: all clean dir-clean

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 
 # BUILD_DIR := $(PWD)/_build
 
-PRIV_DIR := $(MIX_APP_PATH)/priv
+PRIV_DIR := priv
 LIBUSB_NIF := $(PRIV_DIR)/libusb_nif.so
 
 .PHONY: all clean dir-clean

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 
 # BUILD_DIR := $(PWD)/_build
 
-PRIV_DIR := priv
+PRIV_DIR := $(MIX_APP_PATH)/priv
 LIBUSB_NIF := $(PRIV_DIR)/libusb_nif.so
 
 .PHONY: all clean dir-clean

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
 
 # NIF_CFLAGS := -O2 -flat_namespace -undefined suppress
 # NIF_LDFLAGS := -fPIC -shared -pedantic
-LDFLAGS += -fPIC -shared -lusb-1.0
-CFLAGS ?= -fPIC -O2 -Wall -Wextra -Wno-unused-parameter
+NIF_CFLAGS ?= -fPIC -O2 -Wall -Wextra -Wno-unused-parameter
 
 ifeq ($(CROSSCOMPILE),)
 ifeq ($(shell uname),Darwin)
@@ -29,18 +28,59 @@ LIBUSB_NIF := $(PRIV_DIR)/libusb_nif.so
 
 .PHONY: all clean dir-clean
 
-all: $(PRIV_DIR) $(LIBUSB_NIF)
+# MIX_BUILD_PATH := $(PWD)/_build
+LIBUSB_VERSION := 1.0.22
+LIBUSB_SRC_DIR := $(MIX_BUILD_PATH)/libusb-$(LIBUSB_VERSION)
+LIBUSB_BUILD_DIR := $(MIX_BUILD_PATH)/libusb
+LIBUSB_INCLUDE_DIR := $(LIBUSB_BUILD_DIR)/include
+LIBUSB_LIBDIR := $(LIBUSB_BUILD_DIR)/lib
+LIBUSB_LIB := $(LIBUSB_LIBDIR)/libusb-1.0.so
+
+PRIV_DIR := priv
+LIBUSB_CFLAGS := -I$(LIBUSB_INCLUDE_DIR)
+LIBUSB_LDFLAGS := -L$(LIBUSB_LIBDIR) -lusb-1.0
+LIBUSB_NIF_SRC := c_src/libusb_nif.c
+
+NIF_CFLAGS := -O2
+NIF_LDFLAGS := -fPIC -shared -pedantic
+
+LIBUSB_DL := libusb-$(LIBUSB_VERSION).tar.bz2
+LIBUSB_DL_URL := "https://iweb.dl.sourceforge.net/project/libusb/libusb-1.0/libusb-$(LIBUSB_VERSION)/$(LIBUSB_DL)"
+
+.PHONY: all clean libusb-clean dir-clean
+
+all: $(PRIV_DIR) $(LIBUSB_SRC_DIR) $(LIBUSB_NIF)
+
+$(LIBUSB_SRC_DIR):
+	cd $(MIX_BUILD_PATH) && wget $(LIBUSB_DL_URL) && tar xf $(LIBUSB_DL)
 
 $(PRIV_DIR):
 	mkdir -p $(PRIV_DIR)
 
-$(LIBUSB_NIF): c_src/libusb_nif.c
-	$(CC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS) \
-	-o $@ $<
+# $(LIBUSB_NIF): c_src/libusb_nif.c
+# 	echo haai
+# 	$(CC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS) -o $@ $<
+
+$(LIBUSB_NIF): $(LIBUSB_LIB) $(LIBUSB_NIF_SRC)
+	$(CC) -o $@ $(LIBUSB_NIF_SRC) \
+	$(LIBUSB_CFLAGS) $(ERL_CFLAGS) $(NIF_CFLAGS) \
+	$(LIBUSB_LDFLAGS) $(ERL_LDFLAGS) $(NIF_LDFLAGS)
+
+$(LIBUSB_BUILD_DIR):
+	mkdir -p $(LIBUSB_BUILD_DIR)
+
+$(LIBUSB_SRC_DIR)/config.status: $(LIBUSB_BUILD_DIR)
+	cd $(LIBUSB_SRC_DIR) && ./configure --prefix=$(LIBUSB_BUILD_DIR) --host=$(MAKE_HOST) --build=$(BUILD) --disable-udev
+
+$(LIBUSB_LIB): $(LIBUSB_SRC_DIR)/config.status
+	cd $(LIBUSB_SRC_DIR) && make && make install
 
 clean:
 	$(RM) $(LIBUSB_NIF)
 	$(RM) c_src/*.o
+
+libusb-clean:
+	cd $(LIBUSB_SRC_DIR) && make clean
 
 dir-clean: clean libusb-clean
 	$(RM) $(LIBUSB_NOF)

--- a/c_src/libusb_nif.c
+++ b/c_src/libusb_nif.c
@@ -101,8 +101,8 @@ static ERL_NIF_TERM list_devices(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 
 static void libusb_rt_dtor(ErlNifEnv *env, void *obj)
 {
-    // ResourceData *resource_data = (ResourceData *)obj;
-    // enif_fprintf(stderr, "libusb_rt_dtor called\r\n");
+    ResourceData *resource_data = (ResourceData *)obj;
+    libusb_release_interface(resource_data->handle, 0);
 }
 
 static ERL_NIF_TERM get_handle(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {

--- a/c_src/libusb_nif.c
+++ b/c_src/libusb_nif.c
@@ -102,7 +102,7 @@ static ERL_NIF_TERM list_devices(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 static void libusb_rt_dtor(ErlNifEnv *env, void *obj)
 {
     // ResourceData *resource_data = (ResourceData *)obj;
-    enif_fprintf(stderr, "libusb_rt_dtor called\r\n");
+    // enif_fprintf(stderr, "libusb_rt_dtor called\r\n");
 }
 
 static ERL_NIF_TERM get_handle(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {

--- a/c_src/libusb_nif.c
+++ b/c_src/libusb_nif.c
@@ -101,8 +101,12 @@ static ERL_NIF_TERM list_devices(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 
 static void libusb_rt_dtor(ErlNifEnv *env, void *obj)
 {
+    enif_fprintf(stderr, "libusb_rt_dtor called\r\n");
+
     ResourceData *resource_data = (ResourceData *)obj;
-    libusb_release_interface(resource_data->handle, 0);
+    if (resource_data->handle) {
+        libusb_release_interface(resource_data->handle, 0);
+    }
 }
 
 static ERL_NIF_TERM get_handle(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -209,6 +213,7 @@ static ERL_NIF_TERM release_handle(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 
     e = libusb_release_interface(resource_data->handle, 0);
     libusb_close(resource_data->handle);
+    resource_data->handle = 0;
     libusb_exit(NULL);
     return priv->atom_ok;
 }

--- a/lib/libusb.ex
+++ b/lib/libusb.ex
@@ -11,7 +11,7 @@ defmodule LibUsb do
     case :erlang.load_nif(nif_file, 0) do
       :ok -> :ok
       {:error, {:reload, _}} -> :ok
-      {:error, reason} -> Logger.warn("Failed to load nif: #{inspect(reason)}")
+      {:error, reason} -> IO.puts("*** Failed to load nif: #{inspect(reason)}")
     end
   end
 


### PR DESCRIPTION
The library currently attempts to open every USB device while enumerating it when it is looking for the correct vendor/device pair to open.  I think it should only open the device after it has found the correct one. This PR fixes that.